### PR TITLE
Fix

### DIFF
--- a/src/main/java/Problem3/Book.java
+++ b/src/main/java/Problem3/Book.java
@@ -37,11 +37,11 @@ public abstract class Book implements StoreMediaOperations {
         // The bug is caught when
         //  1. newly add tests fail while all old tests still pass
         //  2. remove the bug and use the fix below, all tests pass
-        return id.equals(theOtherBook.id) &&
-                author.equals(theOtherBook.author) &&
-                title.equals(theOtherBook.title);
+        //return id.equals(theOtherBook.id) &&
+        //        author.equals(theOtherBook.author) &&
+        //        title.equals(theOtherBook.title);
 
         // fix is here
-        // return id.equals(theOtherBook.id);
+        return id.equals(theOtherBook.id);
     }
 }

--- a/src/main/java/Problem3/Movie.java
+++ b/src/main/java/Problem3/Movie.java
@@ -37,11 +37,11 @@ public abstract class Movie implements StoreMediaOperations {
         // The bug is caught when
         //  1. newly add tests fail while all old tests still pass
         //  2. remove the bug and use the fix below, all tests pass
-        return id.equals(theOtherMovie.id) &&
-                rating.equals(theOtherMovie.rating) &&
-                title.equals(theOtherMovie.title);
+        //return id.equals(theOtherMovie.id) &&
+        //        rating.equals(theOtherMovie.rating) &&
+        //        title.equals(theOtherMovie.title);
 
         // fix is here
-        //return this.id == ((Movie) obj).id;
+        return this.id == ((Movie) obj).id;
     }
 }

--- a/src/test/java/Problem3Test.java
+++ b/src/test/java/Problem3Test.java
@@ -134,4 +134,32 @@ public class Problem3Test {
         assertEquals(expect, fees);
     }
 
+    @Test
+    public void testBugFixEqualsBookRomance(){
+        BookRomance justID = new BookRomance (null,null);
+        Book justID2 = new BookRomance(justID);
+        assertEquals(justID, justID2);
+    }
+
+    @Test
+    public void testBugFixEqualsBookFiction(){
+        BookFiction justID = new BookFiction (null,null,null);
+        Book justID2 = new BookFiction(justID);
+        assertEquals(justID, justID2);
+    }
+
+    @Test
+    public void testBugFixEqualsMovieAction(){
+        MovieAction justID = new MovieAction (null,null);
+        Movie justID2 = new MovieAction(justID);
+        assertEquals(justID, justID2);
+    }
+
+    @Test
+    public void testBugFixEqualsMovieComedy(){
+        MovieComedy justID = new MovieComedy (null,null);
+        Movie justID2 = new MovieComedy(justID);
+        assertEquals(justID, justID2);
+    }
+
 }


### PR DESCRIPTION
The bug isn’t caught by the tests because none of the constructors initialize author and title as null by default, and in the other equals tests the author and title are set as the same thing. This means that even wrong implementation would result in a test pass. This being the case, I simply made a version of each of the four kinds of media that were provided and set their parameters to null, using the copy constructor to create a copy of each one. This results in four tests that each fail given that the fix is not implemented, but pass when it is implemented. 